### PR TITLE
Add controller and example for using on-board PD control on Solo12

### DIFF
--- a/examples/solo12_real_onboard-pd.py
+++ b/examples/solo12_real_onboard-pd.py
@@ -1,0 +1,28 @@
+"""Basic Solo12 example using sliders and the on-board PD controller."""
+from dynamic_graph_head import ThreadHead
+from dynamic_graph_head.controllers import HoldOnBoardPDController
+import dynamic_graph_manager_cpp_bindings
+from robot_properties_solo.solo12wrapper import Solo12Config
+
+if __name__ == "__main__":
+
+    ###
+    # Create the dgm communication and instantiate the controllers.
+    head = dynamic_graph_manager_cpp_bindings.DGMHead(Solo12Config.dgm_yaml_path)
+
+    head.read()
+    print(head.get_sensor("slider_positions"))
+
+    # Create the controllers.
+    hold_pd_controller = HoldOnBoardPDController(head, 3.0, 0.05, with_sliders=True)
+
+    thread_head = ThreadHead(
+        0.001, hold_pd_controller, head, []  # Run controller at 1000 Hz.
+    )
+
+    # Start the parallel processing.
+    thread_head.start()
+
+    print("Finished controller setup")
+
+    input("Wait for input to finish program.")

--- a/src/dynamic_graph_head/controllers.py
+++ b/src/dynamic_graph_head/controllers.py
@@ -8,16 +8,17 @@ All rights reserved.
 
 import numpy as np
 
+
 class ZeroTorquesController:
     def __init__(self, head):
         # Zero the commands.
-        self.tau = np.zeros_like(head.get_sensor('joint_positions'))
+        self.tau = np.zeros_like(head.get_sensor("joint_positions"))
 
     def warmup(self, thread_head):
         pass
 
     def run(self, thread_head):
-        thread_head.head.set_control('ctrl_joint_torques', self.tau)
+        thread_head.head.set_control("ctrl_joint_torques", self.tau)
 
 
 class HoldPDController:
@@ -29,18 +30,17 @@ class HoldPDController:
         self.slider_scale = np.pi
         self.with_sliders = with_sliders
 
-        self.joint_positions = head.get_sensor('joint_positions')
-        self.joint_velocities = head.get_sensor('joint_velocities')
+        self.joint_positions = head.get_sensor("joint_positions")
+        self.joint_velocities = head.get_sensor("joint_velocities")
 
         if with_sliders:
-            self.slider_positions = head.get_sensor('slider_positions')
+            self.slider_positions = head.get_sensor("slider_positions")
 
     def warmup(self, thread_head):
         self.zero_pos = self.joint_positions.copy()
 
         if self.with_sliders:
             self.slider_zero_pos = self.map_sliders(self.slider_positions)
-
 
     def go_zero(self):
         # TODO: Make this an interpolation.
@@ -51,14 +51,14 @@ class HoldPDController:
 
     def map_sliders(self, sliders):
         sliders_out = np.zeros_like(self.joint_positions)
-        
+
         if self.joint_positions.shape[0] == 12:  # solo12
             slider_A = sliders[0]
             slider_B = sliders[1]
             for i in range(4):
                 sliders_out[3 * i + 0] = slider_A
                 sliders_out[3 * i + 1] = slider_B
-                sliders_out[3 * i + 2] = 2. * (1. - slider_B)
+                sliders_out[3 * i + 2] = 2.0 * (1.0 - slider_B)
 
                 if i >= 2:
                     sliders_out[3 * i + 1] *= -1
@@ -72,36 +72,42 @@ class HoldPDController:
             slider_A = sliders[0]
             for i in range(4):
                 sliders_out[2 * i + 0] = slider_A
-                sliders_out[2 * i + 1] = 2. * (1. - slider_A)
+                sliders_out[2 * i + 1] = 2.0 * (1.0 - slider_A)
 
                 if i >= 2:
                     sliders_out[2 * i + 0] *= -1
                     sliders_out[2 * i + 1] *= -1
-        
+
         elif self.joint_positions.shape[0] == 6:  # bolt
             slider_A = sliders[0]
             slider_B = sliders[1]
 
             for i in range(2):
-                sliders_out[3 * i + 0] = slider_A 
-                sliders_out[3 * i + 1] = slider_B 
-                sliders_out[3 * i + 2] = 1. - slider_B 
+                sliders_out[3 * i + 0] = slider_A
+                sliders_out[3 * i + 1] = slider_B
+                sliders_out[3 * i + 2] = 1.0 - slider_B
 
             sliders_out[3] *= -1
 
         elif self.joint_positions.shape[0] == 2:  #  teststand
             slider_A = sliders[0]
             sliders_out[0] = slider_A
-            sliders_out[1] = 2. * (1. - slider_A)
+            sliders_out[1] = 2.0 * (1.0 - slider_A)
 
         return sliders_out
 
     def run(self, thread_head):
         if self.with_sliders:
-            self.des_position = self.slider_scale * (
-                self.map_sliders(self.slider_positions) - self.slider_zero_pos) + self.zero_pos
+            self.des_position = (
+                self.slider_scale
+                * (self.map_sliders(self.slider_positions) - self.slider_zero_pos)
+                + self.zero_pos
+            )
         else:
             self.des_position = self.zero_pos
 
-        self.tau = self.Kp * (self.des_position - self.joint_positions) - self.Kd * self.joint_velocities
-        self.head.set_control('ctrl_joint_torques', self.tau)
+        self.tau = (
+            self.Kp * (self.des_position - self.joint_positions)
+            - self.Kd * self.joint_velocities
+        )
+        self.head.set_control("ctrl_joint_torques", self.tau)

--- a/src/dynamic_graph_head/controllers.py
+++ b/src/dynamic_graph_head/controllers.py
@@ -5,6 +5,7 @@ Copyright (C) 2021, New York University
 Copyright note valid unless otherwise stated in individual files.
 All rights reserved.
 """
+import abc
 
 import numpy as np
 
@@ -21,8 +22,24 @@ class ZeroTorquesController:
         thread_head.head.set_control("ctrl_joint_torques", self.tau)
 
 
-class HoldPDController:
-    def __init__(self, head, Kp, Kd, with_sliders=False):
+class BaseHoldPDController(abc.ABC):
+    """Base for example controllers using position control.
+
+    If `with_sliders` is set, hardware sliders are used to set the target
+    position.  Otherwise the target position is fixed to zero for all joints.
+    """
+
+    def __init__(self, head, Kp: float, Kd: float, with_sliders: bool=False):
+        """
+        Args:
+            head: Instance of DGHead or SimHead.
+            Kp: P-gain for the PD controller.  The same gain is used for all
+                joints.
+            Kd: D-gain for the PD controller.  The same gain is used for all
+                joints.
+            with_sliders: If true, use hardware sliders to get target position.
+                Otherwise target is fixed to zero.
+        """
         self.head = head
         self.Kp = Kp
         self.Kd = Kd
@@ -96,15 +113,32 @@ class HoldPDController:
 
         return sliders_out
 
-    def run(self, thread_head):
+    def get_desired_position(self):
         if self.with_sliders:
-            self.des_position = (
+            des_position = (
                 self.slider_scale
                 * (self.map_sliders(self.slider_positions) - self.slider_zero_pos)
                 + self.zero_pos
             )
         else:
-            self.des_position = self.zero_pos
+            des_position = self.zero_pos
+
+        return des_position
+
+    @abc.abstractmethod
+    def run(self, thread_head):
+        pass
+
+
+class HoldPDController(BaseHoldPDController):
+    """Example controller using PD control and sending torque commands.
+
+    Runs a PD controller and sends the corresponding torque commands to the
+    robot.  Works for robots that provide a command "ctrl_joint_torques".
+    """
+
+    def run(self, thread_head):
+        self.des_position = self.get_desired_position()
 
         self.tau = (
             self.Kp * (self.des_position - self.joint_positions)
@@ -113,101 +147,27 @@ class HoldPDController:
         self.head.set_control("ctrl_joint_torques", self.tau)
 
 
-class HoldOnBoardPDController:
-    """Example controller using sliders and the on-board PD controller.
+class HoldOnBoardPDController(BaseHoldPDController):
+    """Example controller using the on-board PD controller.
 
     Uses the on-board PD controller of the master board to control the position
-    of the joints.  The target position can be modified through hardware
-    sliders.
+    of the joints.  Works for robots providing commands "ctrl_joint_positions",
+    "ctrl_joint_velocities", "ctrl_joint_position_gains",
+    "ctrl_joint_velocity_gains".
     """
 
     def __init__(self, head, Kp: float, Kd: float, with_sliders: bool = False):
-        self.head = head
+        super().__init__(head, Kp, Kd, with_sliders)
 
-        self.slider_scale = np.pi
-        self.with_sliders = with_sliders
-
-        self.joint_positions = head.get_sensor("joint_positions")
-        self.joint_velocities = head.get_sensor("joint_velocities")
-
+        # set gains of the on-board controller
         kp_array = np.full_like(self.joint_positions, Kp)
         kd_array = np.full_like(self.joint_positions, Kd)
         self.head.set_control("ctrl_joint_position_gains", kp_array)
         self.head.set_control("ctrl_joint_velocity_gains", kd_array)
 
-        if with_sliders:
-            self.slider_positions = head.get_sensor("slider_positions")
-
-    def warmup(self, thread_head):
-        self.zero_pos = self.joint_positions.copy()
-
-        if self.with_sliders:
-            self.slider_zero_pos = self.map_sliders(self.slider_positions)
-
-    def go_zero(self):
-        # TODO: Make this an interpolation.
-        self.zero_pos = np.zeros_like(self.zero_pos)
-
-        if self.with_sliders:
-            self.slider_zero_pos = self.map_sliders(self.slider_positions)
-
-    def map_sliders(self, sliders):
-        sliders_out = np.zeros_like(self.joint_positions)
-
-        if self.joint_positions.shape[0] == 12:  # solo12
-            slider_A = sliders[0]
-            slider_B = sliders[1]
-            for i in range(4):
-                sliders_out[3 * i + 0] = slider_A
-                sliders_out[3 * i + 1] = slider_B
-                sliders_out[3 * i + 2] = 2.0 * (1.0 - slider_B)
-
-                if i >= 2:
-                    sliders_out[3 * i + 1] *= -1
-                    sliders_out[3 * i + 2] *= -1
-
-            # Swap the hip direction.
-            sliders_out[3] *= -1
-            sliders_out[9] *= -1
-
-        elif self.joint_positions.shape[0] == 8:  # solo8
-            slider_A = sliders[0]
-            for i in range(4):
-                sliders_out[2 * i + 0] = slider_A
-                sliders_out[2 * i + 1] = 2.0 * (1.0 - slider_A)
-
-                if i >= 2:
-                    sliders_out[2 * i + 0] *= -1
-                    sliders_out[2 * i + 1] *= -1
-
-        elif self.joint_positions.shape[0] == 6:  # bolt
-            slider_A = sliders[0]
-            slider_B = sliders[1]
-
-            for i in range(2):
-                sliders_out[3 * i + 0] = slider_A
-                sliders_out[3 * i + 1] = slider_B
-                sliders_out[3 * i + 2] = 1.0 - slider_B
-
-            sliders_out[3] *= -1
-
-        elif self.joint_positions.shape[0] == 2:  # teststand
-            slider_A = sliders[0]
-            sliders_out[0] = slider_A
-            sliders_out[1] = 2.0 * (1.0 - slider_A)
-
-        return sliders_out
-
     def run(self, thread_head):
-        if self.with_sliders:
-            self.des_position = (
-                self.slider_scale
-                * (self.map_sliders(self.slider_positions) - self.slider_zero_pos)
-                + self.zero_pos
-            )
-        else:
-            self.des_position = self.zero_pos
-
+        self.des_position = self.get_desired_position()
         des_velocity = np.zeros_like(self.des_position)
+
         self.head.set_control("ctrl_joint_positions", self.des_position)
         self.head.set_control("ctrl_joint_velocities", des_velocity)


### PR DESCRIPTION
## Description

- Add a `HoldOnBoardPDController` which is a copy of `HoldPDController` but using the on-board PD controller of the master board.
- Add an example `solo12_real_onboard-pd.py` which uses this controller.


## How I Tested

Tested on the 12-joint test bench.


## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

- [x] https://github.com/open-dynamic-robot-initiative/solo/pull/111
- [x] https://github.com/open-dynamic-robot-initiative/robot_properties_solo/pull/48

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
